### PR TITLE
Support parsing and tagging lateral joins

### DIFF
--- a/src/syntax/ast.ts
+++ b/src/syntax/ast.ts
@@ -692,6 +692,7 @@ export type From = FromTable
 export interface FromCall extends ExprCall, PGNode {
     alias?: TableAliasName;
     join?: JoinClause | nil;
+    lateral?: true;
     withOrdinality?: boolean;
 };
 
@@ -715,6 +716,7 @@ export interface QNameMapped extends QNameAliased {
 export interface FromTable extends PGNode {
     type: 'table',
     name: QNameMapped;
+    lateral?: true;
     join?: JoinClause | nil;
 }
 
@@ -722,6 +724,7 @@ export interface FromStatement extends PGNode {
     type: 'statement';
     statement: SelectStatement;
     alias: string;
+    lateral?: true;
     columnNames?: Name[] | nil;
     db?: null | nil;
     join?: JoinClause | nil;

--- a/src/to-sql.ts
+++ b/src/to-sql.ts
@@ -1038,6 +1038,9 @@ const visitor = astVisitor<IAstFullVisitor>(m => ({
     fromCall: s => {
 
         join(m, s.join, () => {
+            if (s.lateral) {
+                ret.push("LATERAL ")
+            }
             m.call(s);
             if (s.withOrdinality) {
                 ret.push(' WITH ORDINALITY')
@@ -1065,6 +1068,9 @@ const visitor = astVisitor<IAstFullVisitor>(m => ({
 
         // todo: use 's.db' if defined
         join(m, s.join, () => {
+            if (s.lateral) {
+                ret.push("LATERAL ")
+            }
             ret.push('(');
             m.select(s.statement);
             ret.push(') ');


### PR DESCRIPTION
Postgres has a LATERAL keyword that modifies one of the `from_item`s in a selection. It doesn't have to be an explicit join statement but is most often used as such. This adds support for parsing the LATERAL keyword in front of each from_item type that supports it.

See https://www.postgresql.org/docs/current/sql-select.html

Fixes #122