### PR TITLE
Add support for parenthized subselects

### DIFF
--- a/src/syntax/main.ne
+++ b/src/syntax/main.ne
@@ -66,10 +66,14 @@ statement_noprep
     | functions_statements
 
 
-selection -> select_statement {% unwrap %}
+
+any_selection -> select_statement {% unwrap %}
             | select_values {% unwrap %}
             | with_statement {% unwrap %}
             | with_recursive_statement {% unwrap %}
             | union_statement {% unwrap %}
+
+selection -> lparen selection rparen {% get(1) %}
+          | any_selection {% get(0) %}
 
 selection_paren -> lparen selection rparen {% get(1) %}

--- a/src/syntax/select.spec.ts
+++ b/src/syntax/select.spec.ts
@@ -943,4 +943,91 @@ describe('Select statements', () => {
             type: 'skip locked',
         }
     });
+
+    checkSelect("(select * from foo)",
+        {
+            type: 'select',
+            "columns": [
+                {
+                    "expr": {
+                        "name": "*",
+                        "type": "ref"
+                    }
+                }
+            ],
+            "from": [
+                {
+                    "name": {
+                        "name": "foo"
+                    },
+                    "type": "table"
+                }
+            ]
+        }
+    );
+
+    const testSubselect = {
+        type: 'select',
+        "columns": [
+            {
+                "expr": {
+                    "name": "*",
+                    "type": "ref"
+                }
+            }
+        ],
+        "from": [
+            {
+                "alias": "a",
+                "statement": {
+                    "columns": [
+                        {
+                            "expr": {
+                                "name": "*",
+                                "type": "ref"
+                            }
+                        }
+                    ],
+                    "from": [
+                        {
+                            "name": {
+                                "name": "bar"
+                            },
+                            "type": "table"
+                        }
+                    ],
+                    "type": "select",
+                },
+                "type": "statement"
+            }
+        ]
+    }
+
+    checkSelect(`
+        select * from  (
+            select * from bar
+        ) a`,
+        testSubselect
+    );
+
+    checkSelect(`
+        select * from (
+            (
+                select * from bar
+            )
+        ) a`,
+        testSubselect
+    );
+
+    checkSelect(`
+        select * from (
+            (   
+                (
+                    select * from bar
+                )
+            )
+        ) a`,
+        testSubselect
+    );
+
 });


### PR DESCRIPTION
The real postgres parser supports parentheses around a full select expression, or the select expression in a subselect. This adds support to the parser for these parentheses. They don't change the output AST, but they didn't parse before.